### PR TITLE
Add optional types

### DIFF
--- a/fastgenomics/schemes/manifest_schema.json
+++ b/fastgenomics/schemes/manifest_schema.json
@@ -39,6 +39,10 @@
           "description": "Type of the value of the parameter",
           "enum": ["string", "integer", "float", "bool", "list", "dict"]
         },
+        "Optional": {
+          "description": "Accept null as parameter value in addition to values of the given type?",
+          "type": "boolean"
+        },
         "Description": {
           "description": "Description of the parameter",
           "type": "string"

--- a/tests/sample_app/manifest.json
+++ b/tests/sample_app/manifest.json
@@ -40,6 +40,18 @@
         "Type": "dict",
         "Default": {"foo": 42, "bar": "answer to everything"},
         "Description": "Dict of key-value-pairs"
+      },
+      "OptionalIntValueConcrete": {
+        "Type": "integer",
+        "Optional": true,
+        "Default": 4,
+        "Description": "Either an int or not. default yea"
+      },
+      "OptionalIntValueNull": {
+        "Type": "integer",
+        "Optional": true,
+        "Default": null,
+        "Description": "Either an int or not. default nope"
       }
     },
     "Demands": [

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -63,9 +63,19 @@ def test_parameters(local):
     assert "DictValue" in parameters
     assert parameters["DictValue"] == {"foo": 42, "bar": "answer to everything"}
 
+    assert "OptionalIntValueConcrete" in parameters
+    assert parameters["OptionalIntValueConcrete"] == 4
+
+    assert "OptionalIntValueNull" in parameters
+    assert parameters["OptionalIntValueNull"] is None
+
 
 def test_can_get_specific_parameter(local):
     assert _common.get_parameter("IntValue") == 150
+
+
+def test_can_get_null_parameter(local):
+    assert _common.get_parameter("OptionalIntValueNull") is None
 
 
 def test_can_have_different_type(local, monkeypatch):


### PR DESCRIPTION
Also fixes a bug in `get_parameter` where a parameter with a default of `null`/`None` would be considered missing from the manifest.