### PR TITLE
Make tests work if FASTGenomics is not yet installed

### DIFF
--- a/fastgenomics/_common.py
+++ b/fastgenomics/_common.py
@@ -15,13 +15,11 @@ import json
 import jsonschema
 import typing as ty
 import pkg_resources
+import re
 
 from logging import getLogger
 
 logger = getLogger('fastgenomics.common')
-
-# get / set version
-VERSION = __version__ = pkg_resources.get_distribution('fastgenomics')
 
 # get package paths
 RESOURCES_PATH = pathlib.Path(__file__).parent
@@ -30,6 +28,13 @@ SCHEMA_DIR = RESOURCES_PATH / 'schemes'
 # set default paths
 DEFAULT_APP_DIR = '/app'
 DEFAULT_DATA_ROOT = '/fastgenomics'
+
+# get / set version
+try:
+    with open(RESOURCES_PATH.parent / 'setup.py') as setup_f:
+        VERSION = __version__ = re.search(r"VERSION = '([\d.]+)'", setup_f.read())[1]
+except IOError:
+    VERSION = __version__ = pkg_resources.get_distribution('fastgenomics')
 
 # init cache
 _PATHS = {}


### PR DESCRIPTION
By quick&dirty parsing of the version from setup.py, we don’t need an installed `fastgenomics` package, while `pkg_resources` needs one.

Also, using the version from setup.py is more correct, because if you have an old version installed, that version would be used instead of the development version.

In the long run, we might want to switch to [versioneer](https://github.com/warner/python-versioneer). it sounds complex, but in the end it just means that the reported version is always correct. if your code is matching a git tag like `v0.7` or `0.7`, that’s your version, and if you have additional commits, you have e.g. `0.7-1-g574ab98-dirty`